### PR TITLE
Fix insufficient synchronization in examples

### DIFF
--- a/examples/heap.rs
+++ b/examples/heap.rs
@@ -12,7 +12,7 @@ pub fn new_value(i: usize) -> Vec<u8> {
 fn main() {
   const N: usize = 1000;
   let l = SkipMap::with_options(Options::new().with_capacity(1 << 20)).unwrap();
-  let wg = Arc::new(());
+  let mut wg = Arc::new(());
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();
@@ -21,7 +21,7 @@ fn main() {
       drop(w);
     });
   }
-  while Arc::strong_count(&wg) > 1 {}
+  while Arc::get_mut(&mut wg).is_none() {}
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();

--- a/examples/mmap.rs
+++ b/examples/mmap.rs
@@ -18,7 +18,7 @@ fn main() {
     .write(true);
 
   let l = SkipMap::map_mut("test.wal", open_options, mmap_options).unwrap();
-  let wg = Arc::new(());
+  let mut wg = Arc::new(());
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();
@@ -27,7 +27,7 @@ fn main() {
       drop(w);
     });
   }
-  while Arc::strong_count(&wg) > 1 {}
+  while Arc::get_mut(&mut wg).is_none() {}
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();

--- a/examples/mmap_anon.rs
+++ b/examples/mmap_anon.rs
@@ -14,7 +14,7 @@ fn main() {
 
   let mmap_options = skl::MmapOptions::default().len(1 << 20);
   let l = SkipMap::map_anon(mmap_options).unwrap();
-  let wg = Arc::new(());
+  let mut wg = Arc::new(());
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();
@@ -23,7 +23,7 @@ fn main() {
       drop(w);
     });
   }
-  while Arc::strong_count(&wg) > 1 {}
+  while Arc::get_mut(&mut wg).is_none() {}
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();


### PR DESCRIPTION
The examples use `Arc::strong_count` in order to await all other threads having terminated. Unfortunately, `Arc::strong_count` uses a `Relaxed` atomic to load the value, so this can not be used to establish an ordering, and later leads to a weak memory data race. The alternative is to use `Arc::get_mut`, which uses the internal `is_unique` function, which is unfortunately private and therefore not usable directly.