### PR TITLE
More fixes of insufficient atomics, and make most of the test suite runnable under miri

### DIFF
--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -1199,7 +1199,7 @@ fn test_concurrent_basic_runner(l: Arc<SkipMap>) {
   #[cfg(any(miri, feature = "loom"))]
   const N: usize = 5;
 
-  let wg = Arc::new(());
+  let mut wg = Arc::new(());
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();
@@ -1208,7 +1208,7 @@ fn test_concurrent_basic_runner(l: Arc<SkipMap>) {
       drop(w);
     });
   }
-  while Arc::strong_count(&wg) > 1 {}
+  while Arc::get_mut(&mut wg).is_none() {}
   for i in 0..N {
     let w = wg.clone();
     let l = l.clone();
@@ -1292,7 +1292,7 @@ fn test_concurrent_basic_map_anon_unify() {
 }
 
 #[cfg(feature = "std")]
-fn test_concurrent_basic_big_values_runner(l: Arc<SkipMap>) {
+fn test_concurrent_basic_big_values_runner(mut l: Arc<SkipMap>) {
   #[cfg(not(any(miri, feature = "loom")))]
   const N: usize = 100;
   #[cfg(any(miri, feature = "loom"))]
@@ -1304,7 +1304,7 @@ fn test_concurrent_basic_big_values_runner(l: Arc<SkipMap>) {
       l.get_or_insert(0, &key(i), &big_value(i)).unwrap();
     });
   }
-  while Arc::strong_count(&l) > 1 {}
+  while Arc::get_mut(&mut l).is_none() {}
   // assert_eq!(N, l.len());
   for i in 0..N {
     let l = l.clone();
@@ -1313,7 +1313,7 @@ fn test_concurrent_basic_big_values_runner(l: Arc<SkipMap>) {
       assert_eq!(l.get(0, &k).unwrap().value(), big_value(i), "broken: {i}");
     });
   }
-  while Arc::strong_count(&l) > 1 {}
+  while Arc::get_mut(&mut l).is_none() {}
 }
 
 #[test]

--- a/src/map/tests.rs
+++ b/src/map/tests.rs
@@ -34,9 +34,13 @@ pub fn key(i: usize) -> std::vec::Vec<u8> {
 }
 
 /// Only used for testing
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(miri)))]
 pub fn big_value(i: usize) -> std::vec::Vec<u8> {
   format!("{:01048576}", i).into_bytes()
+}
+#[cfg(all(feature = "std", miri))]
+pub fn big_value(i: usize) -> std::vec::Vec<u8> {
+  format!("{:01024}", i).into_bytes()
 }
 
 /// Only used for testing
@@ -1120,7 +1124,10 @@ fn test_lt_map_anon_unify() {
 }
 
 fn test_basic_large_testcases_in(l: Arc<SkipMap>) {
+  #[cfg(not(miri))]
   let n = 1000;
+  #[cfg(miri)]
+  let n = 200; //takes about 30s on miri, that's large enough
 
   for i in 0..n {
     l.get_or_insert(0, &key(i), &new_value(i)).unwrap();


### PR DESCRIPTION
Hi there, here are some more bugs similar to these of #30.

Additionally, I added some `cfg(miri)`s to make the test suite run under `miri` in a reasonable time.

The reason I am doing all of this is that I noticed that this crate is incompatible with [Tree Borrows](https://www.ralfj.de/blog/2023/06/02/tree-borrows.html) (TB), a new aliasing model for Rust and a potential replacement of Stacked Borrows. While TB was designed to be more lenient than SB, it also gets rid of some dirty hacks, and these unfortunately were relied on this crate (along with a few others which I am doing my best to fix now).

Or, to be more precise: They break `rarena-allocator`, which is a dependency of this crate, but the breakage only shows up in the tests in this crate. Fortunately, that crate is another crate of yours.

Unfortunately, while I have [fixed the TB errors there](https://github.com/al8n/rarena/compare/main...JoJoDeveloping:rarena:fix-tb), the last published version of `rarena-allocator` is quite different from the development `HEAD` (and the version depended on by `skl`), so I am not sure how to best contribute them. Advice on how to proceed is appreciated, if you have any questions about Tree Borrows or why these changes are necessary, feel free to ask.